### PR TITLE
FHIR-37969 Need a way to specify when you are using DEQM and base FHIR Operations, you still use DEQM specific profiles

### DIFF
--- a/FHIR-us-davinci-deqm.xml
+++ b/FHIR-us-davinci-deqm.xml
@@ -2,10 +2,10 @@
 <specification xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ballotUrl="http://hl7.org/fhir/us/davinci-deqm/2020Feb" ciUrl="http://build.fhir.org/ig/HL7/davinci-deqm" defaultVersion="3.0.0" defaultWorkgroup="" gitUrl="https://github.com/HL7/davinci-deqm" url="http://hl7.org/fhir/us/davinci-deqm">
 <version code="current" url="http://build.fhir.org/ig/HL7/davinci-deqm"/>
 <version code="3.0.0" url="http://hl7.org/fhir/us/davinci-deqm/STU3"/>
-<version code="2.1.0" url="http://hl7.org/fhir/us/davinci-deqm/2020Sep"/>
-<version code="2.0.0" url="http://hl7.org/fhir/us/davinci-deqm/STU2"/>
-<version code="1.1.0" url="http://hl7.org/fhir/us/davinci-deqm/2020Feb"/>
-<version code="1.0.0" url="http://hl7.org/fhir/us/davinci-deqm/STU1"/>
+<version code="2.1.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-deqm/2020Sep"/>
+<version code="2.0.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-deqm/STU2"/>
+<version code="1.1.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-deqm/2020Feb"/>
+<version code="1.0.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-deqm/STU1"/>
 <version code="0.2.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-deqm/2019May"/>
 <version code="0.1.0" deprecated="true" url="http://hl7.org/fhir/us/davinci-deqm/2018Sep"/>
 <version code="0.1" deprecated="true"/>
@@ -26,6 +26,7 @@
 <artifact id="StructureDefinition/extension-certificationIdentifier" key="StructureDefinition-extension-certificationIdentifier" name="DEQM Certification Identifier Extension"/>
 <artifact id="StructureDefinition/coverage-deqm" key="StructureDefinition-coverage-deqm" name="DEQM Coverage Profile"/>
 <artifact id="StructureDefinition/datax-measurereport-deqm" key="StructureDefinition-datax-measurereport-deqm" name="DEQM Data Exchange MeasureReport Profile"/>
+<artifact id="OperationDefinition/deqm.evaluate-measure" key="OperationDefinition-deqm.evaluate-measure" name="DEQM Evaluate Measure"/>
 <artifact id="StructureDefinition/extension-gapStatus" key="StructureDefinition-extension-gapStatus" name="DEQM Gap Status Modifier Extension"/>
 <artifact id="StructureDefinition/gaps-bundle-deqm" key="StructureDefinition-gaps-bundle-deqm" name="DEQM Gaps In Care Bundle Profile"/>
 <artifact id="StructureDefinition/gaps-composition-deqm" key="StructureDefinition-gaps-composition-deqm" name="DEQM Gaps In Care Composition Profile"/>

--- a/input/pagecontent/OperationDefinition-deqm.evaluate-measure-intro.md
+++ b/input/pagecontent/OperationDefinition-deqm.evaluate-measure-intro.md
@@ -1,0 +1,8 @@
+
+{% assign id = {{page.id}} %}
+
+<div class="note-to-balloters" markdown="1">
+The type of the return parameter of this $deqm.evaluate-measure is Bundle. 
+</div>
+
+{% include link-list.md %}

--- a/input/pagecontent/operations.md
+++ b/input/pagecontent/operations.md
@@ -7,6 +7,13 @@ The list of operations defined by this implementation guide.
 |---|
 |[$care-gaps Operation](OperationDefinition-care-gaps.html)|
 
+<div class="bg-success" markdown="1">
+[$deqm.evaluate-measure](OperationDefinition-deqm.evaluate-measure.html)
+</div><!-- new-content -->
+
+<div class="note-to-balloters" markdown="1">
+The [$submit-data](http://hl7.org/fhir/R4/measure-operation-submit-data.html) and [$collect-data](http://hl7.org/fhir/R4/measure-operation-collect-data.html) do not specify which MeasureReport profiles to use for the `measureReport` parameter. When used in this IG, $submit-data and $collect-data `measureReport` parameter shall conform to either [DEQM Individual MeasureReport](StructureDefinition-indv-measurereport-deqm.html) or [DEQM Summary MeasureReport](StructureDefinition-summary-measurereport-deqm.html).  
+</div>
 
 <br />
 

--- a/input/resources/OperationDefinition-deqm.evaluate-measure.xml
+++ b/input/resources/OperationDefinition-deqm.evaluate-measure.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OperationDefinition
+    xmlns="http://hl7.org/fhir">
+    <id value="deqm.evaluate-measure"/>
+    <url value="http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/deqm.evaluate-measure"/>
+    <name value="DEQMEvaluateMeasure"/>
+    <title value="DEQM Evaluate Measure"/>
+    <status value="active"/>
+    <kind value="operation"/>
+    <publisher value="Clinical Quality Information Workgroup"/>
+    <contact>
+      <telecom>
+        <system value="url"/>
+        <value value="http://www.hl7.org/Special/committees/cqi/index.cfm"/>
+      </telecom>
+    </contact>
+    <description value="The deqm.evaluate-measure operation is used to calculate an eMeasure and obtain the results."/>
+    <jurisdiction>
+      <coding>
+        <system value="urn:iso:std:iso:3166"/>
+        <code value="US"/>
+        <display value="United States of America"/>
+      </coding>
+    </jurisdiction>
+    <code value="deqm.evaluate-measure"/>
+    <resource value="Measure"/>
+    <system value="false"/>
+    <type value="true"/>
+    <instance value="false"/>
+    <parameter>
+        <name value="periodStart"/>
+        <use value="in"/>
+        <min value="1"/>
+        <max value="1"/>
+        <documentation value="The start of the measurement period. In keeping with the semantics of the date parameter used in the FHIR search operation, the period will start at the beginning of the period implied by the supplied timestamp. E.g. a value of 2014 would set the period start to be 2014-01-01T00:00:00 inclusive"/>
+        <type value="date"/>
+    </parameter>
+    <parameter>
+        <name value="periodEnd"/>
+        <use value="in"/>
+        <min value="1"/>
+        <max value="1"/>
+        <documentation value="The end of the measurement period. The period will end at the end of the period implied by the supplied timestamp. E.g. a value of 2014 would set the period end to be 2014-12-31T23:59:59 inclusive"/>
+        <type value="date"/>
+    </parameter>
+    <parameter>
+        <name value="measure"/>
+        <use value="in"/>
+        <min value="0"/>
+        <max value="1"/>
+        <documentation value="The measure to evaluate. This parameter is only required when the operation is invoked on the resource type, it is not used when invoking the operation on a Measure instance"/>
+        <type value="string"/>
+        <searchType value="reference"/>
+    </parameter>
+    <parameter>
+        <name value="reportType"/>
+        <use value="in"/>
+        <min value="0"/>
+        <max value="1"/>
+        <documentation value="The type of measure report: subject, subject-list, or population. If not specified, a default value of subject will be used if the subject parameter is supplied, otherwise, population will be used"/>
+        <type value="code"/>
+    </parameter>    
+    <parameter>
+        <name value="subject"/>
+        <use value="in"/>
+        <min value="0"/>
+        <max value="1"/>
+        <documentation value="Subject for which the measure will be calculated. If not specified, the measure will be calculated for all subjects that meet the requirements of the measure. If specified, the measure will only be calculated for the referenced subject(s)"/>
+        <type value="string"/>
+        <searchType value="reference"/>
+    </parameter>
+    <parameter>
+        <name value="practitioner"/>
+        <use value="in"/>
+        <min value="0"/>
+        <max value="1"/> 
+        <documentation value="Practitioner (references [QICore Practitioner](http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-practitioner)) for which the measure will be calculated. If specified, the measure will be calculated only for subjects that have a primary relationship to the identified practitioner"/>
+        <type value="string"/>
+        <searchType value="reference"/>
+    </parameter>
+    <parameter>
+        <name value="lastReceivedOn"/>
+        <use value="in"/>
+        <min value="0"/>
+        <max value="1"/>
+        <documentation value="The date the results of this measure were last received. This parameter is only valid for patient-level reports and is used to indicate when the last time a result for this patient was received. This information can be used to limit the set of resources returned for a patient-level report"/>
+        <type value="dateTime"/>
+    </parameter>
+    <parameter>
+        <name value="return"/>
+        <use value="out"/>
+        <min value="0"/>
+        <max value="*"/>
+        <documentation value="Returns [Parameters](https://www.hl7.org/fhir/parameters.html) resource, which contains one or more bundles. The first entry of the bundle is either a [DEQM Individual MeasureReport](StructureDefinition-indv-measurereport-deqm.html) or a [DEQM Summary MeasureReport](StructureDefinition-summary-measurereport-deqm.html) and subsequent entries in the bundle are resources created and/or evaluated as part of the measure calculation. Note that the result of the $evaluate-measure operation must be returned using the Parameters resource, even when the result contains only one bundle, because the cardinality of the return parameter is specified as 0..*"/>
+        <type value="Bundle"/>
+    </parameter>
+</OperationDefinition>


### PR DESCRIPTION
Applied changes to FHIR-37969.
Added a new $deqm.evaluate-measure operation, its intro, and updated Operations.md