### PR TITLE
FHIR-39428 Capability Statement updates

### DIFF
--- a/input/includes/CapabilityStatement-updatetype-snippet.md
+++ b/input/includes/CapabilityStatement-updatetype-snippet.md
@@ -23,6 +23,13 @@
               "valueCode": "incremental"
             }
           ]
+        },{
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-updateType",
+              "valueCode": "snapshot"
+            }
+          ]
         }
       ]
     }

--- a/input/pagecontent/datax.md
+++ b/input/pagecontent/datax.md
@@ -114,7 +114,8 @@ Examples of patient ‘events’ that could trigger the submission of an update:
 
 **Discovery:**
 
-  - A CapabilityStatement is retrieved from a FHIR endpoint
+  - A CapabilityStatement is retrieved from a FHIR endpoint:
+
   `GET|[base]/metadata`
 
   - The Consumer (server) **SHALL** advertise whether it supports snapshot and/or incremental data exchange via its CapabilityStatement using the [DEQM Submit Data Update Type Extension].  The extension is added to the `CapabilityStatement.rest.resource.operation` element for the Submit Data operation and the code is valued `incremental` or `snapshot`, as appropriate.  The snippet shown below would be used for supporting both `incremental` and `snapshot` data exchanges:

--- a/input/pagecontent/datax.md
+++ b/input/pagecontent/datax.md
@@ -114,17 +114,20 @@ Examples of patient ‘events’ that could trigger the submission of an update:
 
 **Discovery:**
 
-  - The Consumer **SHALL** advertise whether it supports snapshot or incremental data exchange via its CapabilityStatement using the [DEQM Submit Data Update Type Extension].  The extension is added to the `CapabilityStatement.rest.resource.operation` element for the Submit Data operation and the code is valued `incremental` or `snapshot` as shown below:
+  - A CapabilityStatement is retrieved from a FHIR endpoint
+  `GET|[base]/metadata`
+
+  - The Consumer (server) **SHALL** advertise whether it supports snapshot and/or incremental data exchange via its CapabilityStatement using the [DEQM Submit Data Update Type Extension].  The extension is added to the `CapabilityStatement.rest.resource.operation` element for the Submit Data operation and the code is valued `incremental` or `snapshot`, as appropriate.  The snippet shown below would be used for supporting both `incremental` and `snapshot` data exchanges:
 
      {% include CapabilityStatement-updatetype-snippet.md %}
 
-   (For a complete example, see the [Consumer Server CapabilityStatement] )
+   (For a complete example showing support for only the `incremental` data exchange, see the [Consumer Server CapabilityStatement] )
 
-   - It is the responsibility of the Producer to discover whether snapshot or incremental data exchange is supported by the inspection of the Consumer’s CapabilityStatement.
+   - It is the responsibility of the Producer (client) to discover whether snapshot, incremental or both data exchange is supported by the inspection of the Consumer’s (server) CapabilityStatement.
 
-   - The Producer **SHALL** populate the required [DEQM Submit Data Update Type Extension] on the [DEQM Data Exchange MeasureReport Profile] to indicate whether the payload is a snapshot or incremental update for both the initial transaction and subsequent updates.
+   - The Producer (client) **SHALL** populate the required [DEQM Submit Data Update Type Extension] on the [DEQM Data Exchange MeasureReport Profile] to indicate whether the payload is a snapshot or incremental update for both the initial transaction and subsequent updates.
 
-  - The Consumer **SHALL** reject the submit data payload if there is mismatch between the Consumer's stated capabilities and the  required modifier extension by returning a `400 Bad Request` http error code. An OperationOutcome **SHALL** be returned stating that the [snapshot/incremental] update is not supported as shown in the following example:
+  - The Consumer (server) **SHALL** reject the submit data payload if there is mismatch between the update type stated in the data exchange MeasureReport submitted by the Producer (client) and the capabilities supported by the Consumer (server)  by returning a `400 Bad Request` http error code. An OperationOutcome **SHALL** be returned stating that the [snapshot/incremental] update is not supported as shown in the following example:
 
     {% include snapshotincremental-notsupported-oo.md %}
 

--- a/input/resources/capabilitystatement-consumer-server.json
+++ b/input/resources/capabilitystatement-consumer-server.json
@@ -125,6 +125,21 @@
                             "definition": "http://hl7.org/fhir/OperationDefinition/Measure-submit-data",
                             "documentation": "**SHALL** Use the [DEQM Submit Data Update Type Extension](http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-submitDataUpdateType) to indicate whether it whether it supports snapshot or incremental data exchange.  **SHALL** reject the submit data payload if there is mismatch between the Consumer\u2019s stated capabilities and the required modifier extension by returning a 400 Bad Request http error code. An OperationOutcome **SHOULD** be returned stating that the [snapshot/incremental] update is not supported .",
                             "name": "submit-data"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-submitDataUpdateType",
+                                    "valueCode": "incremental"
+                                }
+                            ],
+                            "definition": "http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data",
+                            "documentation": "**SHALL** Use the [DEQM Submit Data Update Type Extension](http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-submitDataUpdateType) to indicate whether it whether it supports snapshot or incremental data exchange.  **SHALL** reject the submit data payload if there is mismatch between the Consumer\u2019s stated capabilities and the required modifier extension by returning a 400 Bad Request http error code. An OperationOutcome **SHOULD** be returned stating that the [snapshot/incremental] update is not supported .",
+                            "name": "bulk-submit-data"
                         }
                     ],
                     "supportedProfile": [

--- a/input/resources/capabilitystatement-consumer-server.json
+++ b/input/resources/capabilitystatement-consumer-server.json
@@ -123,7 +123,7 @@
                                 }
                             ],
                             "definition": "http://hl7.org/fhir/OperationDefinition/Measure-submit-data",
-                            "documentation": "**SHALL** Use the [DEQM Submit Data Update Type Extension](http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-submitDataUpdateType) to indicate whether it whether it supports snapshot or incremental data exchange.  **SHALL** reject the submit data payload if there is mismatch between the Consumer\u2019s stated capabilities and the required modifier extension by returning a 400 Bad Request http error code. An OperationOutcome **SHOULD** be returned stating that the [snapshot/incremental] update is not supported .",
+                            "documentation": "**SHALL** Use the [DEQM Submit Data Update Type Extension](http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-submitDataUpdateType) to indicate whether it whether it supports snapshot or incremental data exchange.  **SHALL** reject the submit data payload if there is mismatch between the update type stated in the data exchange MeasureReport submitted by the Producer (client) and the capabilities supported by the Consumer (server) by returning a 400 Bad Request http error code. An OperationOutcome **SHOULD** be returned stating that the [snapshot/incremental] update is not supported .",
                             "name": "submit-data"
                         },
                         {
@@ -138,7 +138,7 @@
                                 }
                             ],
                             "definition": "http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data",
-                            "documentation": "**SHALL** Use the [DEQM Submit Data Update Type Extension](http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-submitDataUpdateType) to indicate whether it whether it supports snapshot or incremental data exchange.  **SHALL** reject the submit data payload if there is mismatch between the Consumer\u2019s stated capabilities and the required modifier extension by returning a 400 Bad Request http error code. An OperationOutcome **SHOULD** be returned stating that the [snapshot/incremental] update is not supported .",
+                            "documentation": "**SHALL** Use the [DEQM Submit Data Update Type Extension](http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-submitDataUpdateType) to indicate whether it whether it supports snapshot or incremental data exchange.  **SHALL** reject the submit data payload if there is mismatch between the update type stated in the data exchange MeasureReport submitted by the Producer (client) and the capabilities supported by the Consumer (server) by returning a 400 Bad Request http error code. An OperationOutcome **SHOULD** be returned stating that the [snapshot/incremental] update is not supported .",
                             "name": "bulk-submit-data"
                         }
                     ],

--- a/input/resources/capabilitystatement-gic-client.json
+++ b/input/resources/capabilitystatement-gic-client.json
@@ -132,8 +132,8 @@
                                     "valueCode": "SHALL"
                                 }
                             ],
-                            "definition": "http://hl7.org/fhir/OperationDefinition/Measure-evaluate-measure",
-                            "name": "evaluate-measure"
+                            "definition": "http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/deqm.evaluate-measure",
+                            "name": "deqm.evaluate-measure"
                         },
                         {
                             "extension": [

--- a/input/resources/capabilitystatement-producer-client.json
+++ b/input/resources/capabilitystatement-producer-client.json
@@ -141,6 +141,17 @@
                             "definition": "http://hl7.org/fhir/OperationDefinition/Measure-submit-data",
                             "documentation": "It is the responsibility of the Producer to discover whether snapshot or incremental data exchange is supported by the inspection of the Consumer Server CapabilityStatement.",
                             "name": "submit-data"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "definition": "http://hl7.org/fhir/us/davinci-deqm/OperationDefinition/bulk-submit-data",
+                            "documentation": "It is the responsibility of the Producer to discover whether snapshot or incremental data exchange is supported by the inspection of the Consumer Server CapabilityStatement.",
+                            "name": "bulk-submit-data"
                         }
                     ],
                     "supportedProfile": [


### PR DESCRIPTION
added bulk-submit-data to consumer-server and producer-client as SHOULD support
change from base FHIR $evaluate-measure to $deqm.evaluate-measure in gic-client

https://jira.hl7.org/browse/FHIR-39428 