### PR TITLE
FHIR-22761 Add PI measure report example

### DIFF
--- a/input/data/ig.yml
+++ b/input/data/ig.yml
@@ -134,6 +134,11 @@ definition:
         reference: MeasureReport/summ-measurereport01
       description: DEQM Summ Measurereport01 example
     - exampleBoolean: true
+      name: Summ PI Measure report
+      reference:
+        reference: MeasureReport/summ-PI
+      description: Summ PI Measure Report example
+    - exampleBoolean: true
       name: Datax Measurereport02
       reference:
         reference: MeasureReport/datax-measurereport02

--- a/input/data/package_list.yml
+++ b/input/data/package_list.yml
@@ -39,3 +39,4 @@ list:
       1. **Applied**: Add asynchronous capability for $submit-data operation ([FHIR-38036](https://jira.hl7.org/browse/FHIR-38036))
       1. **Applied**: Add example MeasureReport for a ratio measure ([FHIR-38073](https://jira.hl7.org/browse/FHIR-38073))
       1. **Applied**: Measure reports should support quality program ([FHIR-39348](https://jira.hl7.org/browse/FHIR-39348))
+      1. **Applied**: Add example PI Measure report ([FHIR-22761](https://jira.hl7.org/browse/FHIR-22761))

--- a/input/examples/MeasureReport-summ-PI.json
+++ b/input/examples/MeasureReport-summ-PI.json
@@ -1,0 +1,109 @@
+{
+    "resourceType": "MeasureReport",
+    "id": "summ-PI",
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/summary-measurereport-deqm"
+        ],
+        "source": "http://example.org/fhir/server"
+    },
+    "extension": [
+        {
+            "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-measureScoring",
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "code": "proportion",
+                        "system": "http://terminology.hl7.org/CodeSystem/measure-scoring"
+                    }
+                ]
+            }
+        }
+    ],
+    "status": "complete",
+    "type": "summary",
+    "measure": "http://hl7.org/fhir/us/cqfmeasures/2023Jul/Measure-measure-pi-exm.html",
+    "date": "2018-09-05T16:59:52.404Z",
+    "period": {
+        "start": "2018-08-01",
+        "end": "2018-09-01"
+    },
+    "reporter": {
+        "reference": "Organization/organization01",
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/extension-reporterGroup",
+                "valueReference": {
+                    "reference": "Group/group01"
+                }
+            }
+        ]
+    },
+    "improvementNotation": {
+        "coding": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/measure-improvement-notation",
+                "code": "increase",
+                "display": "Increased score indicates improvement"
+            }
+        ]
+    },
+    "group": [
+        {
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://example.org/fhir/",
+                        "code": "PI-group",
+                        "display": "Promoting Interoperability Group"
+                    }
+                ],
+                "text": "group-1"
+            },
+            "population": [
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                                "code": "initial-population",
+                                "display": "Initial Population"
+                            }
+                        ]
+                    },
+                    "id": "initial-population",
+                    "count": 100
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                                "code": "numerator",
+                                "display": "Numerator"
+                            }
+                        ]
+                    },
+                    "id": "numerator",
+                    "count": 70
+                },
+                {
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://terminology.hl7.org/CodeSystem/measure-population",
+                                "code": "denominator",
+                                "display": "Denominator"
+                            }
+                        ]
+                    },
+                    "id": "denominator",
+                    "count": 100
+                }
+            ],
+            "measureScore": {
+                "value": 0.7
+            }
+        }
+    ]
+}

--- a/input/includes/summary-measurereports.md
+++ b/input/includes/summary-measurereports.md
@@ -1,2 +1,3 @@
 - [Measurereport Summ Measurereport01](MeasureReport-summ-measurereport01.html)
 - [Measurereport Summ Measurereport02](MeasureReport-summ-measurereport02.html)
+

--- a/input/pagecontent/change-notes.md
+++ b/input/pagecontent/change-notes.md
@@ -178,5 +178,6 @@ The second official published version of the DEQM IG for FHIR R4.
     -  Add asynchronous capability for $submit-data operation ([FHIR-38036](https://jira.hl7.org/browse/FHIR-38036))
     -  Add example MeasureReport for a ratio measure ([FHIR-38073](https://jira.hl7.org/browse/FHIR-38073))
     -  Measure reports should support quality program ([FHIR-39348](https://jira.hl7.org/browse/FHIR-39348))
+    -  Add example PI Measure report ([FHIR-22761](https://jira.hl7.org/browse/FHIR-22761))
 
 {% include link-list.md %}


### PR DESCRIPTION
Added example measure report.
Note:  This example references the example PI measure defined in the CQF Measure IG.  However, the link used in the measure report is a "best guess" as to what the URL for the CQF Measure IG will end up being.  

Note: The PI example measure, as defined in the CQF Measure IG, might need some more detail to make it complete. Doing so might affect the contents of the measure report example in this IG.