### PR TITLE
Update dependency version to cqfm 4.0.0

### DIFF
--- a/input/ig.json
+++ b/input/ig.json
@@ -43,7 +43,7 @@
             "uri": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core"
         },
         {
-            "version": "current",
+            "version": "4.0.0",
             "id": "cqfm",
             "packageId": "hl7.fhir.us.cqfmeasures",
             "uri": "http://hl7.org/fhir/us/cqfmeasures/ImplementationGuide/hl7.fhir.us.cqfmeasures"


### PR DESCRIPTION
Updated the dependency from "current" to "4.0.0" for QM IG (cqfm-measures) that was recently published in August 2023.