### PR TITLE
FHIR-46371 Replaced 'program' parameter with 'manifest' parameter in …

### DIFF
--- a/input/data/package_list.yml
+++ b/input/data/package_list.yml
@@ -54,5 +54,6 @@ list:
       1. **Applied**: Care gap STU note ([FHIR-44573](https://jira.hl7.org/browse/FHIR-44573))([Applied here](vte1.html#practitioner-references)) and ([here](mrp.html#practitioner_footnote))
       1. **Applied**: Summary measure reporting typo ([FHIR-44570](https://jira.hl7.org/browse/FHIR-44570))([Applied here](summary-reporting.html#summary-measure-reporting))
       1. **Applied**: Care gap STU note ([FHIR-44573](https://jira.hl7.org/browse/FHIR-44573))([Applied here](gaps-in-care-reporting.html#stu-note))
+      1. **Applied**: Replaced 'program' parameter with 'manifest' parameter in care gaps  and measure/evaluate operations ([FHIR-46371](https://jira.hl7.org/browse/FHIR-46371))
 
 

--- a/input/pagecontent/change-notes.md
+++ b/input/pagecontent/change-notes.md
@@ -13,7 +13,7 @@ The Data Exchange For Quality Measures Implementation Guide was developed under 
    -  Added clarifying text on the usage of CQL to the general guidance section ([FHIR-4359](https://jira.hl7.org/browse/FHIR-43593))
    -  Added populationDescription extension definition, and inclusion in MeasureReport profiles. ([FHIR-43324](https://jira.hl7.org/browse/FHIR-43324))  
    -  Quality Program value set in Reporting Program extension should be bound less strictly ([FHIR-43321](https://jira.hl7.org/browse/FHIR-43321))([Applied here](StructureDefinition-extension-reportingProgram.html))
-
+   -  Replaced 'program' parameter with 'manifest' parameter in care gaps and measure/evaluate operations ([FHIR-46371](https://jira.hl7.org/browse/FHIR-46371))
 
 ### Changes and Updates for Version 4.0.0 (STU4)
 

--- a/input/resources/OperationDefinition-care-gaps.xml
+++ b/input/resources/OperationDefinition-care-gaps.xml
@@ -122,14 +122,13 @@
         <type value="canonical"/>
     </parameter>
     <parameter>
-        <name value="program"/>
+        <name value="manifest"/>
         <use value="in"/>
         <min value="0"/>
-        <max value="*"/>
-        <documentation value="The programs that a provider (either practitioner or provider organization) participates in, e.g., risk based, value based, or other performance program such as CMS Merit-based Incentive Payment Program (MIPS), Hospital Quality Reporting (HQR) programs. Program is represented in the Measure using element [useContext](https://www.hl7.org/fhir/measure-definitions.html#Measure.useContext). When the code attribute of useContext is program, then the value attribute of useContext represents a specific program. Note that the type of this parameter is a string with a search type of [token](https://www.hl7.org/fhir/search.html#token), so the $care-gaps operation has only simple input parameters and may be invoked using GET."/>
-        <type value="string"/>
-        <searchType value="token"/>
-    </parameter>
+        <max value="1"/>
+        <documentation value="Specifies an asset-collection library that provides dependency version resolution and expansion rules for the operation. See the description of manifest in the Canonical Resource Management Infrastructure IG for a complete description of how manifest values are used to provide defaults for dependency version resolution and expansion parameters. Parameters specified directly in the operation override behaviors specified by the manifest parameter. In general, if this parameter is supplied, it is expected to be used in nested operation calls. For example, in evaluating a measure, if the expansion of a value set is required, this parameter SHALL be supplied to that expansion."/>
+        <type value="canonical"/>
+     </parameter>
     <parameter>
         <name value="return"/>
         <use value="out"/>

--- a/input/resources/OperationDefinition-deqm.evaluate-measure.xml
+++ b/input/resources/OperationDefinition-deqm.evaluate-measure.xml
@@ -44,13 +44,12 @@
         <type value="date"/>
     </parameter>
     <parameter>
-      <name value="program"/> 
-      <use value="in"/> 
-      <min value="0"/> 
-      <max value="1"/> 
-      <documentation value="The quality program being reported via canonical reference to ([Library{CQFMQualityProgram}](http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/library-cqfm)) indicating which quality program is being reported."/> 
-      <type value="canonical"/>
-      <targetProfile value="http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/library-cqfm"/>
+        <name value="manifest"/>
+        <use value="in"/>
+        <min value="0"/>
+        <max value="1"/>
+        <documentation value="Specifies an asset-collection library that provides dependency version resolution and expansion rules for the operation. See the description of manifest in the Canonical Resource Management Infrastructure IG for a complete description of how manifest values are used to provide defaults for dependency version resolution and expansion parameters. Parameters specified directly in the operation override behaviors specified by the manifest parameter. In general, if this parameter is supplied, it is expected to be used in nested operation calls. For example, in evaluating a measure, if the expansion of a value set is required, this parameter SHALL be supplied to that expansion."/>
+        <type value="canonical"/>
     </parameter>
     <parameter>
       <name value="programCode"/> 


### PR DESCRIPTION
…care gaps and measure/evaluate operations

Replaced 'program' parameter with 'manifest' parameter in care gaps and measure/evaluate operations