### PR TITLE
Generated Intro:  Re-ran script with new rule on extensions

### DIFF
--- a/input/pagecontent/StructureDefinition-datax-measurereport-deqm-intro.md
+++ b/input/pagecontent/StructureDefinition-datax-measurereport-deqm-intro.md
@@ -19,7 +19,7 @@ The following data-elements are mandatory (i.e data MUST be present).
 13. group.stratifier.stratum.component.value: The stratum component value, e.g. male
 
 **Each {{site.data.structuredefinitions.[id].type}} Must Support:**
-1. software: Item used in healthcare
+1. software: Extension
 2. vendor: Vendor information
 3. message: Messages encountered while creating the report
 4. inputParameters: What parameters

--- a/input/pagecontent/StructureDefinition-indv-measurereport-deqm-intro.md
+++ b/input/pagecontent/StructureDefinition-indv-measurereport-deqm-intro.md
@@ -4,29 +4,23 @@
 The following data-elements are mandatory (i.e data MUST be present).
 
 **Each {{site.data.structuredefinitions.[id].type}} Must Have:**
-1. extension.url: identifies the meaning of the extension
-2. extension.url: identifies the meaning of the extension
-3. extension.value[x]: Value of extension
-4. extension.value[x]: Value of extension
-5. status: complete \| pending \| error
-6. type: individual \| subject-list \| summary \| data-collection
-7. measure: What measure was calculated
-8. period: What period the report covers
-9. group.stratifier.stratum.component.code: What stratifier component of the group
-10. group.stratifier.stratum.component.value: The stratum component value, e.g. male
+1. status: complete \| pending \| error
+2. type: individual \| subject-list \| summary \| data-collection
+3. measure: What measure was calculated
+4. period: What period the report covers
+5. group.stratifier.stratum.component.code: What stratifier component of the group
+6. group.stratifier.stratum.component.value: The stratum component value, e.g. male
 
 **Each {{site.data.structuredefinitions.[id].type}} Must Support:**
 1. reportingProgram: Reporting program
 2. inputParameters: What parameters
 3. supplementalData: Supplemental Data
-4. criteriaReference: Criteria reference
-5. description: Description of the supplemental data
-6. scoring: proportion \| ratio \| continuous-variable \| cohort \| composite
-7. vendor: Vendor information
-8. cehrt: CMS EHR Certifciation ID
-9. software: Extension
-10. message: Evaluation messages
-11. popref: Criteria reference
+4. scoring: proportion \| ratio \| continuous-variable \| cohort \| composite
+5. vendor: Vendor information
+6. cehrt: CMS EHR Certifciation ID
+7. software: Extension
+8. message: Evaluation messages
+9. popref: Criteria reference
 
 <!--End Generated Intro (DO NOT REMOVE)-->
 

--- a/input/pagecontent/StructureDefinition-summary-measurereport-deqm-intro.md
+++ b/input/pagecontent/StructureDefinition-summary-measurereport-deqm-intro.md
@@ -4,61 +4,55 @@
 The following data-elements are mandatory (i.e data MUST be present).
 
 **Each {{site.data.structuredefinitions.[id].type}} Must Have:**
-1. extension.url: identifies the meaning of the extension
-2. extension.url: identifies the meaning of the extension
-3. extension.value[x]: Value of extension
-4. extension.value[x]: Value of extension
-5. status: complete \| pending \| error
-6. type: individual \| subject-list \| summary \| data-collection
-7. measure: What measure was calculated
-8. date: When the report was generated. Note: The language in R5 was changed to calculated.  We are clarifying that intent.
-9. reporter: Organization that generated the MeasureReport
-10. period: What period the report covers
-11. period.start: Starting time with inclusive boundary
-12. period.end: End time with inclusive boundary, if not ongoing
-13. group: Measure results for each group
-14. group.population.code: initial-population \| numerator \| numerator-exclusion \| denominator \| denominator-exclusion \| denominator-exception \| measure-population \| measure-population-exclusion \| measure-observation
-15. group.stratifier.stratum.component.code: What stratifier component of the group
-16. group.stratifier.stratum.component.value: The stratum component value, e.g. male
-17. group.stratifier.stratum.population.code: initial-population \| numerator \| numerator-exclusion \| denominator \| denominator-exclusion \| denominator-exception \| measure-population \| measure-population-exclusion \| measure-observation
-18. group.stratifier.stratum.population.count: Size of the population
+1. status: complete \| pending \| error
+2. type: individual \| subject-list \| summary \| data-collection
+3. measure: What measure was calculated
+4. date: When the report was generated. Note: The language in R5 was changed to calculated.  We are clarifying that intent.
+5. reporter: Organization that generated the MeasureReport
+6. period: What period the report covers
+7. period.start: Starting time with inclusive boundary
+8. period.end: End time with inclusive boundary, if not ongoing
+9. group: Measure results for each group
+10. group.population.code: initial-population \| numerator \| numerator-exclusion \| denominator \| denominator-exclusion \| denominator-exception \| measure-population \| measure-population-exclusion \| measure-observation
+11. group.stratifier.stratum.component.code: What stratifier component of the group
+12. group.stratifier.stratum.component.value: The stratum component value, e.g. male
+13. group.stratifier.stratum.population.code: initial-population \| numerator \| numerator-exclusion \| denominator \| denominator-exclusion \| denominator-exception \| measure-population \| measure-population-exclusion \| measure-observation
+14. group.stratifier.stratum.population.count: Size of the population
 
 **Each {{site.data.structuredefinitions.[id].type}} Must Support:**
 1. reportingProgram: Reporting program
 2. inputParameters: What parameters
 3. supplementalData: Supplemental Data
-4. criteriaReference: Criteria reference
-5. description: Description of the supplemental data
-6. scoring: proportion \| ratio \| continuous-variable \| cohort \| composite
-7. vendor: Vendor information
-8. cehrt: CMS EHR Certifciation ID
-9. software: Extension
-10. message: Evaluation messages
-11. group: Group of practitioners responsible for a report
-12. improvementNotation: increase \| decrease
-13. group.id: Unique id for inter-element referencing
-14. scoring: proportion \| ratio \| continuous-variable \| cohort \| composite
-15. calculatedDate: The date the score was calculated
-16. groupImprovementNotation: increase \| decrease
-17. description: Description of the group
-18. numeratorMembership: Provides the number of subjects in the numerator population membership.
-19. denominatorMembership: Provides the number of subjects in the denominator population membership.
-20. measurePopulationMembership: Provides the number of subjects in the measure population membership.
-21. group.code: Meaning of the group
-22. group.population: The populations in the group
-23. countQuantity: Count as a Quantity
-24. description: Description of the population
-25. group.population.count: Size of the population
-26. group.measureScore: What score this group achieved
-27. altscoretype: Possible additional measureScore value types
-28. group.stratifier: Stratification results
-29. description: Description of the stratifier
-30. group.stratifier.code: What stratifier of the group
-31. group.stratifier.stratum: Stratum results, one for each unique value, or set of values, in the stratifier, or stratifier components
-32. group.stratifier.stratum.value: The stratum value, e.g. male
-33. group.stratifier.stratum.population: Population results in this stratum
-34. group.stratifier.stratum.measureScore: What score this stratum achieved
-35. strataltscoretype: Possible additional measureScore value types
+4. scoring: proportion \| ratio \| continuous-variable \| cohort \| composite
+5. vendor: Vendor information
+6. cehrt: CMS EHR Certifciation ID
+7. software: Extension
+8. message: Evaluation messages
+9. group: Group of practitioners responsible for a report
+10. improvementNotation: increase \| decrease
+11. group.id: Unique id for inter-element referencing
+12. scoring: proportion \| ratio \| continuous-variable \| cohort \| composite
+13. calculatedDate: The date the score was calculated
+14. groupImprovementNotation: increase \| decrease
+15. description: Description of the group
+16. numeratorMembership: Provides the number of subjects in the numerator population membership.
+17. denominatorMembership: Provides the number of subjects in the denominator population membership.
+18. measurePopulationMembership: Provides the number of subjects in the measure population membership.
+19. group.code: Meaning of the group
+20. group.population: The populations in the group
+21. countQuantity: Count as a Quantity
+22. description: Description of the population
+23. group.population.count: Size of the population
+24. group.measureScore: What score this group achieved
+25. altscoretype: Possible additional measureScore value types
+26. group.stratifier: Stratification results
+27. description: Description of the stratifier
+28. group.stratifier.code: What stratifier of the group
+29. group.stratifier.stratum: Stratum results, one for each unique value, or set of values, in the stratifier, or stratifier components
+30. group.stratifier.stratum.value: The stratum value, e.g. male
+31. group.stratifier.stratum.population: Population results in this stratum
+32. group.stratifier.stratum.measureScore: What score this stratum achieved
+33. strataltscoretype: Possible additional measureScore value types
 
 <!--End Generated Intro (DO NOT REMOVE)-->
 


### PR DESCRIPTION
- Reran script with new rule: parent extensions only (children of extension skipped)
- To determine an entry in this json array is a parent extension, I look for the id to end in ".extension:+sliceName". 
- All the children to that extension have ids contain ".extension:sliceName" plus a dot (.), these entries are skipped.