### PR TITLE
FHIR-4891 Set measure scoring value to 'extensible'

### DIFF
--- a/input/resources/StructureDefinition-extension-measureScoring.json
+++ b/input/resources/StructureDefinition-extension-measureScoring.json
@@ -60,7 +60,7 @@
         "min": 1,
         "max": "1",
         "binding": {
-          "strength": "required",
+          "strength": "extensible",
           "valueSet": "http://terminology.hl7.org/ValueSet/measure-scoring"
           
         }


### PR DESCRIPTION
The original PR for this effort  [(HL7/davinci-deqm#243)](https://github.com/HL7/davinci-deqm/pull/243#issuecomment-2689099599) was merged and closed.

This PR implements the change of binding of the valueCodeableConcept to 'extensible', per the comment on that PR. 