### PR TITLE
FHIR-50091 supplementalData extension models both value and extension

### DIFF
--- a/input/pagecontent/change-notes.md
+++ b/input/pagecontent/change-notes.md
@@ -42,6 +42,7 @@ The Data Exchange For Quality Measures Implementation Guide was developed under 
    - remove MS from DEQM profiles ([FHIR-50052](https://jira.hl7.org/browse/FHIR-50052)) Applied ([here](StructureDefinition-summary-measurereport-deqm.html)) and ([here](StructureDefinition-indv-measurereport-deqm.html))
    - Care Gaps Support for MultiRate Measures (revised) ([FHIR-48758](https://jira.hl7.org/browse/FHIR-48758)) Applied ([here](StructureDefinition-gaps-detectedissue-deqm.html))
    - Code Systems should be in THO or be granted an exemption ([FHIR-48082](https://jira.hl7.org/browse/FHIR-48082)) Applied to ignoreWarnings.txt
+   - supplementalData extension models both value and extension ([FHIR-50091](https://jira.hl7.org/browse/FHIR-50091)) Applied ([here](StructureDefinition-indv-measurereport-deqm.html)), ([here](StructureDefinition-subjectlist-measurereport-deqm.html)), and ([here](StructureDefinition-summary-measurereport-deqm-intro.md))
 
 ### Changes and Updates for STU5 Ballot for 2024Sept Version of the DEQM IG.
 

--- a/input/resources/StructureDefinition-indv-measurereport-deqm.xml
+++ b/input/resources/StructureDefinition-indv-measurereport-deqm.xml
@@ -122,8 +122,8 @@
       </type>
       <mustSupport value="true"/>
     </element>
-    <element id="MeasureReport.extension:supplementalData.extension:criteriaReference">
-      <path value="MeasureReport.extension.extension"/>
+    <element id="MeasureReport.extension:supplementalData.value[x].extension:criteriaReference">
+      <path value="MeasureReport.extension.value[x].extension"/>
       <sliceName value="criteriaReference"/>
       <min value="0"/>
       <max value="1"/>
@@ -133,16 +133,15 @@
       </type>
       <mustSupport value="true"/>
     </element>
-    <element id="MeasureReport.extension:supplementalData.extension:populationDescription">
-      <path value="MeasureReport.extension.extension"/>
+    <element id="MeasureReport.extension:supplementalData.value[x].extension:description">
+      <path value="MeasureReport.extension.value[x].extension"/>
       <sliceName value="description"/>
       <short value="Description of the supplemental data"/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="Extension"/>
-        <profile
-          value="http://hl7.org/fhir/StructureDefinition/measurereport-populationDescription"/>
+        <profile value="http://hl7.org/fhir/StructureDefinition/measurereport-populationDescription"/>
       </type>
       <mustSupport value="true"/>
     </element>

--- a/input/resources/StructureDefinition-subjectlist-measurereport-deqm.xml
+++ b/input/resources/StructureDefinition-subjectlist-measurereport-deqm.xml
@@ -99,8 +99,8 @@
       </type>
       <mustSupport value="true"/>
     </element>
-    <element id="MeasureReport.extension:supplementalData.extension:criteriaReference">
-      <path value="MeasureReport.extension.extension"/>
+    <element id="MeasureReport.extension:supplementalData.value[x].extension:criteriaReference">
+      <path value="MeasureReport.extension.value[x].extension"/>
       <sliceName value="criteriaReference"/>
       <min value="0"/>
       <max value="1"/>
@@ -110,16 +110,15 @@
       </type>
       <mustSupport value="true"/>
     </element>
-    <element id="MeasureReport.extension:supplementalData.extension:populationDescription">
-      <path value="MeasureReport.extension.extension"/>
+    <element id="MeasureReport.extension:supplementalData.value[x].extension:description">
+      <path value="MeasureReport.extension.value[x].extension"/>
       <sliceName value="description"/>
       <short value="Description of the supplemental data"/>
       <min value="0"/>
       <max value="1"/>
       <type>
         <code value="Extension"/>
-        <profile
-          value="http://hl7.org/fhir/StructureDefinition/measurereport-populationDescription"/>
+        <profile value="http://hl7.org/fhir/StructureDefinition/measurereport-populationDescription"/>
       </type>
       <mustSupport value="true"/>
     </element>
@@ -434,13 +433,13 @@
     </element>
     <element id="MeasureReport.group.population">
       <path value="MeasureReport.group.population"/>
-      <mustSupport value="true"/>
       <constraint>
         <key value="deqm-8"/>
         <severity value="error"/>
         <human value="The population must either have a count (integer) or a countQuantity (quantity), but not both."/>
         <expression value="extension('http://hl7.org/fhir/StructureDefinition/measurereport-countQuantity').exists() xor count.exists()"/>
       </constraint>
+      <mustSupport value="true"/>
     </element>
     <element id="MeasureReport.group.population.extension:countQuantity">
       <path value="MeasureReport.group.population.extension"/>
@@ -534,8 +533,8 @@
     </element>
     <element id="MeasureReport.group.stratifier.stratum.population">
       <path value="MeasureReport.group.stratifier.stratum.population"/>
-      <mustSupport value="true"/>
       <condition value="popCountQuantity"/>
+      <mustSupport value="true"/>
     </element>
     <element id="MeasureReport.group.stratifier.stratum.population.extension:countQuantity">
       <path value="MeasureReport.group.stratifier.stratum.population.extension"/>

--- a/input/resources/StructureDefinition-summary-measurereport-deqm.xml
+++ b/input/resources/StructureDefinition-summary-measurereport-deqm.xml
@@ -101,29 +101,6 @@
       </type>
       <mustSupport value="true"/>
     </element>
-    <element id="MeasureReport.extension:supplementalData.extension:criteriaReference">
-      <path value="MeasureReport.extension.extension"/>
-      <sliceName value="criteriaReference"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="Extension"/>
-        <profile value="http://hl7.org/fhir/StructureDefinition/cqf-criteriaReference"/>
-      </type>
-      <mustSupport value="true"/>
-    </element>
-    <element id="MeasureReport.extension:supplementalData.extension:description">
-      <path value="MeasureReport.extension.extension"/>
-      <sliceName value="description"/>
-      <short value="Description of the supplemental data"/>
-      <min value="0"/>
-      <max value="1"/>
-      <type>
-        <code value="Extension"/>
-        <profile value="http://hl7.org/fhir/StructureDefinition/measurereport-populationDescription"/>
-      </type>
-      <mustSupport value="true"/>
-    </element>
     <element id="MeasureReport.extension:scoring">
       <path value="MeasureReport.extension"/>
       <sliceName value="scoring"/>
@@ -137,6 +114,32 @@
       <condition value="deqm-2"/>
       <condition value="deqm-3"/>
       <condition value="deqm-6"/>
+      <mustSupport value="true"/>
+    </element>
+    <element id="MeasureReport.extension:supplementalData.value[x]">
+      <path value="MeasureReport.extension.value[x]"/>
+    </element>
+    <element id="MeasureReport.extension:supplementalData.value[x].extension:criteriaReference">
+      <path value="MeasureReport.extension.value[x].extension"/>
+      <sliceName value="criteriaReference"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Extension"/>
+        <profile value="http://hl7.org/fhir/StructureDefinition/cqf-criteriaReference"/>
+      </type>
+      <mustSupport value="true"/>
+    </element>
+    <element id="MeasureReport.extension:supplementalData.value[x].extension:description">
+      <path value="MeasureReport.extension.value[x].extension"/>
+      <sliceName value="description"/>
+      <short value="Description of the supplemental data"/>
+      <min value="0"/>
+      <max value="1"/>
+      <type>
+        <code value="Extension"/>
+        <profile value="http://hl7.org/fhir/StructureDefinition/measurereport-populationDescription"/>
+      </type>
       <mustSupport value="true"/>
     </element>
     <element id="MeasureReport.extension:vendor">


### PR DESCRIPTION
![Screenshot 2025-04-09 at 12 56 32 PM](https://github.com/user-attachments/assets/6cfd63b6-cfbd-4a92-8868-bbaed00f5016)

Screen shot shows only 1 - they all have the same warnings about versioning which is to be addressed at a later time.
There was no need to "Create publisher exemption(s) to avoid errors/warnings due to "description" not being allowed on Reference data type." as that warning did not appear.
https://jira.hl7.org/browse/FHIR-50091