### PR TITLE
FHIR-50173 - Allow Ratio as an alternate score type

### DIFF
--- a/input/pagecontent/StructureDefinition-extension-alternateScoreType-intro.md
+++ b/input/pagecontent/StructureDefinition-extension-alternateScoreType-intro.md
@@ -1,5 +1,7 @@
 {% assign id = {{include.id}} %}
 <!--Begin Generated Intro Tag (DO NOT REMOVE)-->
+Scoring type is determined by the measure's <a href="https://hl7.org/fhir/us/cqfmeasures/measure-conformance.html#population-criteria">population criteria.</a>
+
 ### Mandatory Data Elements and Terminology
 The following data-elements are mandatory (i.e data MUST be present).
 

--- a/input/pagecontent/change-notes.md
+++ b/input/pagecontent/change-notes.md
@@ -42,6 +42,7 @@ The Data Exchange For Quality Measures Implementation Guide was developed under 
    - remove MS from DEQM profiles ([FHIR-50052](https://jira.hl7.org/browse/FHIR-50052)) Applied ([here](StructureDefinition-summary-measurereport-deqm.html)) and ([here](StructureDefinition-indv-measurereport-deqm.html))
    - Care Gaps Support for MultiRate Measures (revised) ([FHIR-48758](https://jira.hl7.org/browse/FHIR-48758)) Applied ([here](StructureDefinition-gaps-detectedissue-deqm.html))
    - Code Systems should be in THO or be granted an exemption ([FHIR-48082](https://jira.hl7.org/browse/FHIR-48082)) Applied to ignoreWarnings.txt
+   - Allow Ratio as an alternateScoreType ([FHIR-50173](https://jira.hl7.org/browse/FHIR-50173)) Applied ([here](StructureDefinition-extension-alternateScoreType.html))
 
 ### Changes and Updates for STU5 Ballot for 2024Sept Version of the DEQM IG.
 

--- a/input/resources/StructureDefinition-extension-alternateScoreType.xml
+++ b/input/resources/StructureDefinition-extension-alternateScoreType.xml
@@ -16,7 +16,7 @@
       <value value="http://www.hl7.org/Special/committees/cqi/index.cfm"/>
     </telecom>
   </contact>
-  <description value="Possible value types for the measureScore elements *in addition to* the standard [Quantity](http://hl7.org/fhir/R4/datatypes.html#Quantity) type. The alternate type is determined by the Quality Measure [Aggregate Method](http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod) extension used on the Measure.   The reported type of the measureScore for continuous variable measures is determined by the result type of the aggregate method operation. This extension corresponds to the measureScore types in the FHIR R5 version of MeasureReport."/>
+  <description value="Possible value types for the measureScore elements *in addition to* the standard [Quantity](http://hl7.org/fhir/R4/datatypes.html#Quantity) type. For continuous variable measures, the alternate type is determined by the Quality Measure [Aggregate Method](http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-aggregateMethod) extension used on the Measure. The reported type of the measureScore for continuous variable measures is determined by the result type of the aggregate method operation. This extension corresponds to the measureScore types in the FHIR R5 version of MeasureReport."/>
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166"/>
@@ -73,6 +73,9 @@
       </type>
       <type>
         <code value="boolean"/>
+      </type>
+      <type>
+        <code value="Ratio"/>
       </type>
     </element>
   </differential>


### PR DESCRIPTION
Allow Ratio as an alternate score type and update the intro with some additional guidance

![image](https://github.com/user-attachments/assets/9bb889d1-a7cb-4936-9da9-3f0cd5750c85)
