### PR TITLE
[FHIR-56028](https://jira.hl7.org/browse/FHIR-56028)

### DIFF
--- a/input/resources/OperationDefinition-evaluate.xml
+++ b/input/resources/OperationDefinition-evaluate.xml
@@ -137,9 +137,10 @@
             are part of a provider group. This parameter is reflected in the reporter element
             of the resulting MeasureReport(s). This parameter cannot be used with the reporter
             parameter."/> 
-        <allowedType value="Practitioner"/>
-        <allowedType value="PractitionerRole"/>
-        <allowedType value="Organization"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
+        <searchType value="reference"/>
     </parameter>
     <parameter>
         <name value="excludeEvaluatedResources"/>


### PR DESCRIPTION
Updated OperationDefinition-evaluate per [FHIR-56028](https://jira.hl7.org/browse/FHIR-56028) with xml for parameter: "reporterResource" that matches what is in OperationDefinition/collect-data. Note that both OperationDefinitions now have similar error and warnings to resolve.