### PR TITLE
FHIR-56902

### DIFF
--- a/input/pagecontent/glossary.md
+++ b/input/pagecontent/glossary.md
@@ -53,6 +53,7 @@ For additional definitions see the [eCQI Resource Center Glossary]
 |CQL |Clinical Quality Language|
 |CQM |Clinical Quality Measures|
 |DEQM|Data Exchange For Quality Measures|
+|dQM |Digital Quality Measure|
 |eCQM|electronic Clinical Quality Measures|
 |EHR|Electronic Health Record|
 |FHIR|Fast Healthcare Interoperability Resources|

--- a/input/pagecontent/guidance.md
+++ b/input/pagecontent/guidance.md
@@ -2,7 +2,7 @@
 ### Introduction
 Clinical Quality Measures are a common tool used throughout healthcare to help evaluate and understand the impact and quality of the care being provided to an individual or population.
 
-The Data Exchange for Quality Measure (DEQM) Implementation Guide defines the interactions for several purposes in the Quality Measure Ecosystem.  
+The Data Exchange for Quality Measures (DEQM) Implementation Guide defines the interactions for several purposes in the Quality Measure Ecosystem.  
 
 - The first interaction is when a Producer, such as a practitioner, or owner of data needs to exchange that data with a Consumer of that data, such as a payer, a registry or public health agency. We call this the [Data Exchange] Scenario. Examples of this interaction might be when a provider has patient information from a recent visit that he needs to share with a payer under a value based contract. There may also be use cases where the Producer in this scenario is a Payer and needs to exchange data with a Provider.
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -16,6 +16,8 @@ Interoperability challenges have limited many stakeholders in the healthcare com
 
 The guide is based upon prior work from the [US Core](https://hl7.org/fhir/us/core/) and [QI-Core](https://hl7.org/fhir/us/qicore/) Implementation Guides and the [QRDA Category I](https://www.hl7.org/implement/standards/product_brief.cfm?product_id=35) and [QRDA III](https://www.hl7.org/implement/standards/product_brief.cfm?product_id=286) reporting specifications. Initially supported by the [Da Vinci] initiative, development and ongoing maintenance of this specification is managed by the sponsoring HL7 [Clinical Quality Information (CQI)] and [Clinical Decision Support (CDS)] workgroups. Implementation feedback is incorporated through the standard HL7 balloting process.
 
+Quality measures are increasingly represented using standardized, computable approaches across the healthcare ecosystem. Terms such as electronic Clinical Quality Measure (eCQM) and digital Quality Measure (dQM) are used throughout the industry to describe specific formats of quality measures. For the purposes of this IG, all such measures are referred to as "quality measures".
+
 ### How to read this Guide
 
 This Guide is divided into several pages which are listed at the top of each page in the menu bar.


### PR DESCRIPTION
[FHIR-56902](https://jira.hl7.org/browse/FHIR-56902): Reference measures consistently

1. Added specified statement Home page, at the end of 1.1 Introduction.
2. Found 2 uses of "QMIG" (no space). One is on the Change Notes page and is left as-is. The other is a possible typo, not yet addressed.
3. Reviewed and found no other uses of QM & QMs acronyms (separate CQM, dQM, eCQM, and DEQM)
4. Reviewed and found no uses of "Quality Measure" phrase that should be to lower case.

**NOTE:** _Did not address_ the Jira ticket's original description of inconsistency between uses of "measures" (Home page) and "CQMs" (Framwork pages).